### PR TITLE
Use more portable set of regular expressions

### DIFF
--- a/run_scaled
+++ b/run_scaled
@@ -65,8 +65,8 @@ done
 
 declare -i UNSCALED_RESOLUTION_X
 declare -i UNSCALED_RESOLUTION_Y
-UNSCALED_RESOLUTION_X=`xrandr | sed -n -e 's/Screen 0:.*current \([0-9]\+\) x \([0-9]\+\).*/\1/p'`
-UNSCALED_RESOLUTION_Y=`xrandr | sed -n -e 's/Screen 0:.*current \([0-9]\+\) x \([0-9]\+\).*/\2/p'`
+UNSCALED_RESOLUTION_X=`xrandr | sed -n -e 's/Screen 0:.*current \([0-9][0-9]*\) x \([0-9][0-9]*\).*/\1/p'`
+UNSCALED_RESOLUTION_Y=`xrandr | sed -n -e 's/Screen 0:.*current \([0-9][0-9]*\) x \([0-9][0-9]*\).*/\2/p'`
 
 UNSCALED_RESOLUTION="$( bc <<<"$UNSCALED_RESOLUTION_X / $SCALING_FACTOR" )x$( bc <<<"$UNSCALED_RESOLUTION_Y / $SCALING_FACTOR" )"
 


### PR DESCRIPTION
Not every sed(1) implementation supports "+" as a way of saying "one or
more".

This way run_scaled "just works"(tm) on FreeBSD.