### PR TITLE
Ensure `bc` uses `scale=0` when computing the unscaled resolution.

### DIFF
--- a/run_scaled
+++ b/run_scaled
@@ -68,7 +68,7 @@ declare -i UNSCALED_RESOLUTION_Y
 UNSCALED_RESOLUTION_X=`xrandr | sed -n -e 's/Screen 0:.*current \([0-9]\+\) x \([0-9]\+\).*/\1/p'`
 UNSCALED_RESOLUTION_Y=`xrandr | sed -n -e 's/Screen 0:.*current \([0-9]\+\) x \([0-9]\+\).*/\2/p'`
 
-UNSCALED_RESOLUTION="$( bc <<<"$UNSCALED_RESOLUTION_X / $SCALING_FACTOR" )x$( bc <<<"$UNSCALED_RESOLUTION_Y / $SCALING_FACTOR" )"
+UNSCALED_RESOLUTION="$( bc <<<"scale=0; $UNSCALED_RESOLUTION_X / $SCALING_FACTOR" )x$( bc <<<"scale=0; $UNSCALED_RESOLUTION_Y / $SCALING_FACTOR" )"
 
 DISPLAYNUM=:`shuf -i 10000-99999999 -n 1`
 ESCAPED_PARAMS=`printf '%q ' "$@"`


### PR DESCRIPTION
Fixes #37.